### PR TITLE
fix: change Role property to have a private setter for better encapsu…

### DIFF
--- a/FULLSTACKFURY.EduSpace.API/IAM/Domain/Model/Aggregates/Account.cs
+++ b/FULLSTACKFURY.EduSpace.API/IAM/Domain/Model/Aggregates/Account.cs
@@ -30,7 +30,7 @@ public class Account
 
     [BsonElement("role")]
     [BsonRepresentation(BsonType.String)]
-    public ERoles Role { get; }
+    public ERoles Role { get; private set; }
 
     public Account UpdateUsername(string username)
     {


### PR DESCRIPTION
This pull request makes a minor change to the `Account` aggregate model, specifically around the `Role` property. The change updates the property to allow its value to be set privately within the class, which can help with encapsulation and future internal modifications.

* Changed the `Role` property in the `Account` class to have a private setter, allowing it to be set only within the class.…lation